### PR TITLE
Fixes #1 by checking if mScrollView is already instantiated.

### DIFF
--- a/library/src/main/java/asia/ivity/android/marqueeview/MarqueeView.java
+++ b/library/src/main/java/asia/ivity/android/marqueeview/MarqueeView.java
@@ -152,7 +152,7 @@ public class MarqueeView extends LinearLayout {
             throw new RuntimeException("MarqueeView must have exactly one child element.");
         }
 
-        if (changed) {
+        if (changed && mScrollView == null) {
             View v = getChildAt(0);
             // Fixes #1: Exception when using android:layout_width="fill_parent". There seems to be an additional ScrollView parent.
             if (v instanceof ScrollView && ((ScrollView) v).getChildCount() == 1) {


### PR DESCRIPTION
When the text in  a TextView is updated, onLayout is called. This results in an exception, because the child of the MarqueeView is a ScrollView (which was already instantiated when onLayout was called the first time).